### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/interview/project/ai-search/1.ipynb
+++ b/interview/project/ai-search/1.ipynb
@@ -18,7 +18,7 @@
      "text": [
       "ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
       "llama-index 0.9.14.post3 requires openai>=1.1.0, but you have openai 0.28.1 which is incompatible.\n",
-      "pyautogen 0.2.0 requires openai~=1.2, but you have openai 0.28.1 which is incompatible.\n",
+      "ag2 0.2.0 requires openai~=1.2, but you have openai 0.28.1 which is incompatible.\n",
       "\n",
       "[notice] A new release of pip is available: 23.3.2 -> 24.0\n",
       "[notice] To update, run: python.exe -m pip install --upgrade pip\n"


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
